### PR TITLE
MasterCard/master

### DIFF
--- a/src/main/java/com/mastercard/api/moneysend/v2/mapping/domain/TransferRequest.java
+++ b/src/main/java/com/mastercard/api/moneysend/v2/mapping/domain/TransferRequest.java
@@ -971,7 +971,7 @@ public class TransferRequest {
         @XmlElement(name = "AccountNumber")
         protected Long accountNumber;
         @XmlElement(name = "ExpiryMonth")
-        protected Integer expiryMonth;
+        protected String expiryMonth;
         @XmlElement(name = "ExpiryYear")
         protected Integer expiryYear;
 
@@ -995,7 +995,7 @@ public class TransferRequest {
          * Gets the value of the expiryMonth property.
          * 
          */
-        public Integer getExpiryMonth() {
+        public String getExpiryMonth() {
             return expiryMonth;
         }
 
@@ -1003,7 +1003,7 @@ public class TransferRequest {
          * Sets the value of the expiryMonth property.
          * 
          */
-        public void setExpiryMonth(Integer value) {
+        public void setExpiryMonth(String value) {
             this.expiryMonth = value;
         }
 

--- a/src/main/java/com/mastercard/api/moneysend/v2/mapping/domain/TransferRequest.java
+++ b/src/main/java/com/mastercard/api/moneysend/v2/mapping/domain/TransferRequest.java
@@ -971,7 +971,7 @@ public class TransferRequest {
         @XmlElement(name = "AccountNumber")
         protected Long accountNumber;
         @XmlElement(name = "ExpiryMonth")
-        protected String expiryMonth;
+        protected Integer expiryMonth;
         @XmlElement(name = "ExpiryYear")
         protected Integer expiryYear;
 
@@ -995,7 +995,7 @@ public class TransferRequest {
          * Gets the value of the expiryMonth property.
          * 
          */
-        public String getExpiryMonth() {
+        public Integer getExpiryMonth() {
             return expiryMonth;
         }
 
@@ -1003,7 +1003,7 @@ public class TransferRequest {
          * Sets the value of the expiryMonth property.
          * 
          */
-        public void setExpiryMonth(String value) {
+        public void setExpiryMonth(Integer value) {
             this.expiryMonth = value;
         }
 

--- a/src/test/java/com/mastercard/api/moneysend/v2/mapping/services/TransferServiceTest.java
+++ b/src/test/java/com/mastercard/api/moneysend/v2/mapping/services/TransferServiceTest.java
@@ -36,7 +36,7 @@ public class TransferServiceTest extends TestCase {
         transferRequestCard.getSenderAddress().setPostalCode(22207);
         transferRequestCard.getSenderAddress().setCountry("USA");
         transferRequestCard.getFundingCard().setAccountNumber(5184680430000006L);
-        transferRequestCard.getFundingCard().setExpiryMonth("09");
+        transferRequestCard.getFundingCard().setExpiryMonth(11);
         transferRequestCard.getFundingCard().setExpiryYear(2014);
         transferRequestCard.setFundingUCAF("MjBjaGFyYWN0ZXJqdW5rVUNBRjU=1111");
         transferRequestCard.setFundingMasterCardAssignedId(123456);

--- a/src/test/java/com/mastercard/api/moneysend/v2/mapping/services/TransferServiceTest.java
+++ b/src/test/java/com/mastercard/api/moneysend/v2/mapping/services/TransferServiceTest.java
@@ -36,7 +36,7 @@ public class TransferServiceTest extends TestCase {
         transferRequestCard.getSenderAddress().setPostalCode(22207);
         transferRequestCard.getSenderAddress().setCountry("USA");
         transferRequestCard.getFundingCard().setAccountNumber(5184680430000006L);
-        transferRequestCard.getFundingCard().setExpiryMonth(11);
+        transferRequestCard.getFundingCard().setExpiryMonth("09");
         transferRequestCard.getFundingCard().setExpiryYear(2014);
         transferRequestCard.setFundingUCAF("MjBjaGFyYWN0ZXJqdW5rVUNBRjU=1111");
         transferRequestCard.setFundingMasterCardAssignedId(123456);


### PR DESCRIPTION
Don’t think Passing a value like 09 (september) as an Integer is
possible since it’ll be considered as an octal value in java. Since
MasterCard requires month to be a two digit value (and rejects anything
else), it makes sense to represent this as a String instead. Currently
using expiryMonth as a String without any problems.